### PR TITLE
Add atom feeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages'
 gem 'octopress-autoprefixer'
+gem 'jekyll-feed'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,8 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-feed
   octopress-autoprefixer
 
 BUNDLED WITH
-   2.1.4
+   2.3.25

--- a/_config.yml
+++ b/_config.yml
@@ -8,5 +8,5 @@ plugins:
 - jekyll-feed
 
 feed:
-collections:
-- conferences
+  collections:
+  - conferences

--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,6 @@ markdown: kramdown
 
 collections:
 - conferences
+
+plugins:
+- jekyll-feed

--- a/_config.yml
+++ b/_config.yml
@@ -6,3 +6,7 @@ collections:
 
 plugins:
 - jekyll-feed
+
+feed:
+collections:
+- conferences


### PR DESCRIPTION
Feeds will be available at https://www.flutterconferences.com/feed/conferences.xml

See https://mvolpato.github.io/flutter-conferences/feed/conferences.xml for an example.