### PR TITLE
Droidcon London 2024

### DIFF
--- a/_conferences/droidcon-london-october-2024.md
+++ b/_conferences/droidcon-london-october-2024.md
@@ -1,0 +1,14 @@
+---
+name: "Droidcon London"
+website: https://london.droidcon.com/
+location: London, Endland
+online: false
+
+date_start: 2024-10-31
+date_end:   2024-11-01
+
+cfp:
+  start: 2024-05-24
+  end:   2024-08-15
+  site: https://sessionize.com/droidcon-london-2024
+---


### PR DESCRIPTION
Even though the page doesn't mention Flutter, they have a Flutter track according to the CfP.

- https://london.droidcon.com/
- https://sessionize.com/droidcon-london-2024