### PR TITLE
Add missing 2026 Flutter conferences

### DIFF
--- a/_conferences/flutter-tech-summit-june-2026.md
+++ b/_conferences/flutter-tech-summit-june-2026.md
@@ -1,0 +1,15 @@
+---
+name: "Flutter Tech Summit"
+website: https://www.fluttertechsummit.com/
+location: Warsaw, Poland
+online: false
+
+date_start: 2026-06-09
+date_end:   2026-06-09
+
+
+cfp:
+  start: 2026-01-01
+  end:   2026-01-01
+  site: https://www.fluttertechsummit.com/
+---

--- a/_conferences/flutter-tech-summit-june-2026.md
+++ b/_conferences/flutter-tech-summit-june-2026.md
@@ -7,7 +7,6 @@ online: false
 date_start: 2026-06-09
 date_end:   2026-06-09
 
-
 cfp:
   start: 2026-01-01
   end:   2026-01-01

--- a/_conferences/fluttercon-india-november-2026.md
+++ b/_conferences/fluttercon-india-november-2026.md
@@ -1,0 +1,14 @@
+---
+name: "Fluttercon India"
+website: https://india.fluttercon.dev/
+location: Bengaluru, India
+online: false
+
+date_start: 2026-11-21
+date_end:   2026-11-21
+
+cfp:
+  start: 2026-01-01
+  end:   2026-01-01
+  site: https://india.fluttercon.dev/
+---

--- a/_conferences/flutterconf-latam-september-2026.md
+++ b/_conferences/flutterconf-latam-september-2026.md
@@ -1,0 +1,14 @@
+---
+name: "FlutterConf Latam"
+website: https://flutterconflatam.dev/
+location: Cancun, Mexico
+online: false
+
+date_start: 2026-09-22
+date_end:   2026-09-23
+
+cfp:
+  start: 2026-01-01
+  end:   2026-01-01
+  site: https://flutterconflatam.dev/
+---

--- a/_conferences/flutterconf-spain-may-2026.md
+++ b/_conferences/flutterconf-spain-may-2026.md
@@ -1,0 +1,14 @@
+---
+name: "FlutterConf Spain"
+website: https://flutterconf.es/
+location: Málaga, Spain
+online: false
+
+date_start: 2026-05-08
+date_end:   2026-05-09
+
+cfp:
+  start: 2026-01-01
+  end:   2026-05-08
+  site: https://docs.google.com/forms/d/e/1FAIpQLSfxBFH1rIGd9DLrdDGM7UFxhTFqL3PjqTNtjuD_3NuoS4yYNw/viewform
+---

--- a/_conferences/googleio-may-2026.md
+++ b/_conferences/googleio-may-2026.md
@@ -1,0 +1,14 @@
+---
+name: "Google I/O"
+website: https://io.google/2026/
+location: Mountain View, USA
+online: true
+
+date_start: 2026-05-19
+date_end:   2026-05-20
+
+cfp:
+  start: 2026-01-01
+  end:   2026-01-01
+  site: https://io.google/2026/
+---

--- a/_conferences/next-app-devcon-october-2026.md
+++ b/_conferences/next-app-devcon-october-2026.md
@@ -1,6 +1,6 @@
 ---
-name: "next.app devcon - fluttercon"
-website: https://usa.droidcon.com/fluttercon
+name: "NextApp DevCon - Fluttercon Europe"
+website: https://fluttercon.dev/
 location: Berlin, Germany
 online: false
 
@@ -8,7 +8,7 @@ date_start: 2026-10-07
 date_end:   2026-10-09
 
 cfp:
-  start: 2026-10-07
-  end:   2026-10-07
-  site: https://usa.droidcon.com/fluttercon
+  start: 2026-01-01
+  end:   2026-01-01
+  site: https://fluttercon.dev/
 ---


### PR DESCRIPTION
Adds 5 missing 2026 conferences sourced from [LeanCode's Flutter conferences list](https://leancode.co/blog/flutter-conferences-and-meetups):

- **FlutterConf Spain** — Málaga, Spain, May 8-9
- **Google I/O** — Mountain View, USA, May 19-20
- **Flutter Tech Summit** — Warsaw, Poland, June 9
- **FlutterConf Latam** — Cancun, Mexico, Sep 22-23
- **Fluttercon India** — Bengaluru, India, Nov 21

Also updates NextApp DevCon metadata (name, website, CFP info).